### PR TITLE
:construction_worker: Skip npm auth for no-op releases

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -32,7 +32,28 @@ jobs:
         run: npm run build
       - name: Run tests
         run: npm run test
+      - name: Check if a release is required
+        id: release-check
+        run: |
+          node <<'NODE'
+          const fs = require("fs");
+          const semanticRelease = require("semantic-release");
+          semanticRelease({ dryRun: true, ci: false })
+            .then((result) => {
+              fs.appendFileSync(
+                process.env.GITHUB_OUTPUT,
+                `required=${Boolean(result)}\n`
+              );
+            })
+            .catch((error) => {
+              console.error(error);
+              process.exit(1);
+            });
+          NODE
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
       - name: Release
+        if: steps.release-check.outputs.required == 'true'
         run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Summary
- Add a tokenless semantic-release dry run before the real release step.
- Skip the credentialed release step when gitmoji analysis finds no releasable changes.
- Preserve npm publishing behavior for real releases, which will still require valid npm authentication.

This follows up on #455: its workflow-only `:arrow_up:` merge built and tested successfully, but semantic-release 19 verified the stale `NPM_TOKEN` before determining that no release was needed.

## Root cause
`@koj/config` enables npm publishing whenever `NPM_TOKEN` is non-empty. semantic-release runs plugin verification before commit analysis, so an expired token failed even for a non-release dependency commit. The disabled Issues setting then caused a secondary 410 when semantic-release tried to report the failure.

## Test plan
- Node 14.21.3 / npm 6.14.18: `npm ci`
- `npm run build`
- `npm test -- --runInBand` (2 suites, 40 tests)
- Parse all workflows as YAML
- Run the exact release-check script with no `NPM_TOKEN`; it outputs `required=false`
- `actionlint` (only the same pre-existing `actions/cache@v3` finding remains in the edited workflow)
- `git diff --check`
- Independent Claude review: passed with no security or logic findings
