### PR TITLE
:arrow_up: Update actions/cache to v6

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 14
       - name: Cache node modules
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         env:
           cache-name: cache-node-modules
         with:


### PR DESCRIPTION
## Summary
- updates the default-branch cache step from `actions/cache@v3` to `actions/cache@v6`
- preserves the current no-op semantic-release preflight added after the stale Dependabot branch diverged
- supersedes #454, whose cached merge ref would remove that release hardening

## Test plan
- [x] Node 14.21.3 / npm 6.14.18: `npm ci`
- [x] `npm run build`
- [x] `npm test -- --runInBand` (40 tests)
- [x] `npm pack --dry-run`
- [x] workflow parses as YAML and passes actionlint
- [x] verified `actions/cache@v6` resolves to v6.1.0 (`55cc834`) with the Node 24 runtime and preserves the configured `path`, `key`, and `restore-keys` inputs
